### PR TITLE
Capability

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,7 @@
   <exec_depend>controller_manager_msgs</exec_depend>
   <exec_depend>diagnostic_msgs</exec_depend>
   <exec_depend>ros_graph_parser</exec_depend>
-  <exec_depend>rospkg</exec_depend>
+  <exec_depend>python-rospkg</exec_depend>
 
   <export>
   </export>

--- a/resources/cob4-25_manipualtion.rossystem
+++ b/resources/cob4-25_manipualtion.rossystem
@@ -1,0 +1,12 @@
+RosSystem { Name 'cob4-25_manipulation_capability'
+    RosComponents ( 
+        ComponentInterface { name 'manipulation'
+            RosPublishers {
+                RosPublisher '/tf' {RefPublisher 'cob4./base/driver./base/driver./tf'}}
+            RosSubscribers {
+                RosSubscriber '/arm_right/joint_trajectory_controller/command' {RefSubscriber 'cob4./arm_right/driver./arm_right/driver./arm_right/joint_trajectory_controller/command'},
+                RosSubscriber '/arm_left/joint_trajectory_controller/command' {RefSubscriber 'cob4./arm_left/driver./arm_left/driver./arm_left/joint_trajectory_controller/command'}}
+            RosParameters {
+                RosParameter 'robot_description' { RefParameter "cob4.parameters_node.parameters_node./robot_description"}
+            }}
+)}

--- a/resources/cob4-25_navigation.rossystem
+++ b/resources/cob4-25_navigation.rossystem
@@ -1,0 +1,11 @@
+RosSystem { Name 'cob4-25_navigation_capability'
+    RosComponents ( 
+        ComponentInterface { name 'navigation'
+            RosPublishers {
+                RosPublisher '/scan_unified' {RefPublisher 'cob4./scan_unifier_b1_2193_6719186776096933542./scan_unifier_b1_2193_6719186776096933542./scan_unified'},
+                RosPublisher '/tf' {RefPublisher 'cob4./base/driver./base/driver./tf'},
+                RosPublisher '/base/odometry_controller/odometry' {RefPublisher 'cob4./base/driver./base/driver./base/odometry_controller/odometry'}}
+            RosSubscribers {
+                RosSubscriber '/base/twist_controller/command' { RefSubscriber 'cob4./base/driver./base/driver./base/twist_controller/command'}
+        }}
+)}

--- a/src/rosgraph_monitor/parser.py
+++ b/src/rosgraph_monitor/parser.py
@@ -87,13 +87,13 @@ class ModelParser(object):
         _action_servers = Keyword("RosActionServers").suppress()
         _action_server = Keyword("RosActionServer").suppress(
         ) | Keyword("RosServer").suppress()
-        _ref_server = Keyword("RefServer").suppress()
+        _ref_server = Keyword("RefServer").suppress() | Keyword("RefActionServer").suppress()
 
         # Actio Clients Def
         _action_clients = Keyword("RosActionClients").suppress()
         _action_client = Keyword("RosActionClient").suppress(
         ) | Keyword("RosClient").suppress()
-        _ref_action_client = Keyword("RefClient").suppress()
+        _ref_action_client = Keyword("RefClient").suppress() | Keyword("RefActionClient").suppress()
 
         # Topic Connections Def
         _topic_connections = Keyword("TopicConnections").suppress()

--- a/src/rosgraph_monitor/parser.py
+++ b/src/rosgraph_monitor/parser.py
@@ -196,8 +196,8 @@ class ModelParser(object):
                 self._parse_from_file()
             else:
                 self._parse_from_string()
-        except Exception as e:
-            print(e.args)   # Should set a default 'result'?
+        except ParseException as e:
+            print(ParseException.explain(e, depth=0))   # Should set a default 'result'?
         return self._result
 
 


### PR DESCRIPTION
Note: Handles only one capability at the moment.

Tested with cob4 sim for [navigation capability](https://github.com/ipa-nhg/ros-model-experiments/blob/7be7efd29abd7a09276e43f4ba10da3a39cef156/cob4-25/cob4-25_monitoring/cob4-25_navigation.rossystem).

Error message received:
```
level: 2
name: "cob4-25_navigation_capability"
message: "Capability incompatible"
hardware_id: ''
values: 
  - 
    key: "publishers"
    value: "tf"
```
TODO: 
- Use the name of the capability in the diagnostics msg
- Handle multiple capabilities (use multiple instances of `ROSGraphObserver`?)